### PR TITLE
Merge sfrinaldi/ci-GitHub-pages into master

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,72 @@
+name: Deploy Doxygen Docs to GitHub Pages
+
+on:
+    push:
+        branches:
+            - master
+            - sfrinaldi/ci-github-pages
+    pull_request:
+        types: [opened,reopened,edited,synchronize]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout Repo
+              uses: actions/checkout@v4
+
+            #- name: Generate Token
+            #  id: generate-token
+            #  uses: actions/create-github-app-token@v2
+            #  with:
+            #    app-id: ${{ vars.APP_ID }}
+            #    private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+            - name: Setup Python
+              uses: actions/setup-python@v5
+              with:
+                python-version: '3.x'
+            
+            - name: Install Dependencies
+              run: |
+                pip install sphinx sphinx-rtd-them ghp-import
+                DEBIAN_FRONTEND=noninteractive apt install -y doxygen graphviz
+
+            - name: Build Sphinx Docs
+              run: |
+                mkdir -p doxygen
+                mkdir -p doxygen/Filterwheel/processor
+                cd Filterwheel/processor/dox
+                doxygen
+                cd ../../../
+                mkdir -p doxygen/FilterwheelTq144/fpga  
+                cd FilterwheelTq144/fpga/dox
+                doxygen 
+                cd ../../../
+                mkdir -p doxygen/FineSteeringMirrorController/processor
+                cd FineSteeringMirrorController/processor/Main/dox
+                doxygen 
+                cd ../../../
+                mkdir -p doxygen/FineSteeringMirrorController/fpga
+                cd FineSteeringMirrorController/fpga/dox
+                doxygen
+                cd ../../../
+                cd dox
+                doxygen
+
+            - name: Deploy GitHub Pages
+              uses: peaceiris/actions-gh-pages@v4
+              if: github.ref == 'refs/heads/main'
+              with:
+                github_token: ${{ secrets.GITHUB_TOKEN}}
+                publish_dir: doxygen
+
+            - name: Upload Pages
+              uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                name: firmware-pages
+                path: |
+                    doxygen/*
+            

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -30,37 +30,46 @@ jobs:
             
             - name: Install Dependencies
               run: |
-                pip install sphinx sphinx-rtd-them ghp-import
-                DEBIAN_FRONTEND=noninteractive apt install -y doxygen graphviz
+                sudo apt-get install doxygen graphviz -y
 
-            - name: Build Sphinx Docs
+            - name: Build Doxygen Docs
               run: |
                 mkdir -p doxygen
                 mkdir -p doxygen/Filterwheel/processor
                 cd Filterwheel/processor/dox
                 doxygen
-                cd ../../../
+                cd $GITHUB_WORKSPACE
                 mkdir -p doxygen/FilterwheelTq144/fpga  
                 cd FilterwheelTq144/fpga/dox
                 doxygen 
-                cd ../../../
+                cd $GITHUB_WORKSPACE
                 mkdir -p doxygen/FineSteeringMirrorController/processor
                 cd FineSteeringMirrorController/processor/Main/dox
                 doxygen 
-                cd ../../../
+                cd $GITHUB_WORKSPACE
                 mkdir -p doxygen/FineSteeringMirrorController/fpga
                 cd FineSteeringMirrorController/fpga/dox
                 doxygen
-                cd ../../../
+                cd $GITHUB_WORKSPACE
                 cd dox
                 doxygen
 
+            - name: Prep for gh-pages
+              run: |
+                cd $GITHUB_WORKSPACE
+                mkdir -p gh-pages
+                mv doxygen/html/* gh-pages
+                mv doxygen/FineSteeringMirrorController gh-pages
+                mv doxygen/FilterwheelTq144 gh-pages
+                mv doxygen/Filterwheel gh-pages
+                cd $GITHUB_WORKSPACE
+
             - name: Deploy GitHub Pages
               uses: peaceiris/actions-gh-pages@v4
-              if: github.ref == 'refs/heads/main'
+              if: github.ref == 'refs/heads/sfrinaldi/ci-github-pages'
               with:
                 github_token: ${{ secrets.GITHUB_TOKEN}}
-                publish_dir: doxygen
+                publish_dir: gh-pages/
 
             - name: Upload Pages
               uses: actions/upload-artifact@v4
@@ -68,5 +77,5 @@ jobs:
               with:
                 name: firmware-pages
                 path: |
-                    doxygen/*
+                    gh-pages/*
             

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -4,7 +4,6 @@ on:
     push:
         branches:
             - master
-            - sfrinaldi/ci-github-pages
     pull_request:
         types: [opened,reopened,edited,synchronize]
 
@@ -15,13 +14,6 @@ jobs:
         steps:
             - name: Checkout Repo
               uses: actions/checkout@v4
-
-            #- name: Generate Token
-            #  id: generate-token
-            #  uses: actions/create-github-app-token@v2
-            #  with:
-            #    app-id: ${{ vars.APP_ID }}
-            #    private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
             - name: Setup Python
               uses: actions/setup-python@v5
@@ -66,9 +58,9 @@ jobs:
 
             - name: Deploy GitHub Pages
               uses: peaceiris/actions-gh-pages@v4
-              if: github.ref == 'refs/heads/sfrinaldi/ci-github-pages'
+              if: github.ref == 'refs/heads/master'
               with:
-                github_token: ${{ secrets.GITHUB_TOKEN}}
+                github_token: ${{ secrets.GITHUB_TOKEN }}
                 publish_dir: gh-pages/
 
             - name: Upload Pages

--- a/Filterwheel/processor/dox/Doxyfile
+++ b/Filterwheel/processor/dox/Doxyfile
@@ -68,7 +68,7 @@ PROJECT_LOGO           = ./../../../dox/UASAL_Logo.png
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = .
+OUTPUT_DIRECTORY       = ../../../doxygen/Filterwheel/processor
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create up to 4096
 # sub-directories (in 2 levels) under the output directory of each output format

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 ESC Firmware Source Code
 
 ## Documentation
-Doxygen-generated documentation can be found [here](#).
+Doxygen-generated documentation can be found [here](https://uasal.github.io/firmware/).

--- a/dox/Doxyfile
+++ b/dox/Doxyfile
@@ -23,10 +23,10 @@ INPUT = homepage.dox
 RECURSIVE = NO
 
 # Output dir
-OUTPUT_DIRECTORY = ../doxygen/homepage
+OUTPUT_DIRECTORY = ../doxygen/
 
 # Any overarching high-level documentation files can be included here (not the case atm)
 FILE_PATTERNS = *.dox
 
 # Link documentation of each folder
-HTML_EXTRA_FILES = ../../Filterwheel/processor/html/index.html ../../FilterwheelTq144/fpga/html/index.html ../../FineSteeringMirrorController/processor/html/index.html ../../FineSteeringMirrorController/fpga/html/index.html
+HTML_EXTRA_FILES = Filterwheel/processor/html/index.html FilterwheelTq144/fpga/html/index.html FineSteeringMirrorController/processor/html/index.html FineSteeringMirrorController/fpga/html/index.html

--- a/dox/homepage.dox
+++ b/dox/homepage.dox
@@ -1,12 +1,12 @@
 /**
  * @mainpage ESC Firmware Documentation
  *
- * Welcome to the firmare documentation for the ESC project.
+ * Welcome to the firmware documentation for the ESC project.
  *
  * Here are the links to the specific hardware documentation:
  *
- * - [Filterwheel Processor Documentation](../../Filterwheel/processor/html/index.html)
- * - [FilterwheelTq144 FPGA Documentation](../../FilterwheelTq144/fpga/html/index.html)
- * - [Fine Steering Mirror Processor Documentation](../../FineSteeringMirrorController/processor/html/index.html)
- * - [Fine Steering Mirror FPGA Documentation](../../FineSteeringMirrorController/fpga/html/index.html)
+ * - [Filterwheel Processor Documentation](Filterwheel/processor/html/index.html)
+ * - [FilterwheelTq144 FPGA Documentation](FilterwheelTq144/fpga/html/index.html)
+ * - [Fine Steering Mirror Processor Documentation](FineSteeringMirrorController/processor/html/index.html)
+ * - [Fine Steering Mirror FPGA Documentation](FineSteeringMirrorController/fpga/html/index.html)
  */


### PR DESCRIPTION
Since the original repository of this had the GitLab Pages being generated, I had a ci-workflow that I could just adjust a bit and add to here to get it to work for GitHub now that it has been moved.  Did have to slightly do some adjustments on the doxygen files but nothing too much. 

Feel free to merge in whenever you want for this, no rush. 