### PR TITLE
Add Makefile to install headers from 'include' dir.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,5 @@ FineSteeringMirrorController/Liberopeekfifos/designer/FineSteeringMirror/min_fil
 FineSteeringMirrorController/Liberopeekfifos/designer/FineSteeringMirror/options.txt
 FineSteeringMirrorController/Liberopeekfifos/designer/FineSteeringMirror/pinslacks.txt
 FineSteeringMirrorController/Liberopeekfifos/designer/FineSteeringMirror/user_sets.txt
+
+build/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+# Install headers from `include` directory into PREFIX directory.
+# By default, PREFIX is /usr/local/include/summerDevice, but it can be
+# overridden by setting the PREFIX variable when invoking make. For example:
+#   make install PREFIX=/opt/MAgAOX/source/summerDevice
+# Note: installing / uninstalling to /usr/local requires root privileges:
+#   sudo make install / uninstall
+
+PREFIX ?= /usr/local/include/summerDevice
+DESTDIR ?=
+
+SRCDIR := include
+BUILD_DIR := build
+MANIFEST := $(BUILD_DIR)/install_manifest.txt
+
+INSTALL_DIR := install -d
+
+ALL_HEADERS := $(shell find $(SRCDIR) -type f -name '*.h' -o -type f -name '*.hpp')
+
+.PHONY: all build install uninstall clean help
+
+# Default: build list of headers to be installed
+all: build
+
+build:
+	@echo "Building header list in $(BUILD_DIR)"
+	@mkdir -p $(BUILD_DIR)
+	@find $(SRCDIR) -type f -name '*.h' -o -type f -name '*.hpp' > $(BUILD_DIR)/headers.list
+	@echo "Found $$(wc -l < $(BUILD_DIR)/headers.list) header files to install"
+
+install: uninstall build
+	@echo "Installing headers to $(DESTDIR)$(PREFIX)"
+	@> $(MANIFEST)
+	@while IFS= read -r f; do \
+		rel=$${f#$(SRCDIR)/}; \
+		dest=$(DESTDIR)$(PREFIX)/$$rel; \
+		$(INSTALL_DIR) "$$(dirname "$$dest")"; \
+		cp "$$f" "$$dest"; \
+		echo "$$dest" >> $(MANIFEST); \
+	done < $(BUILD_DIR)/headers.list
+	@echo "Installed $$(wc -l < $(MANIFEST)) headers; manifest written to $(MANIFEST)"
+
+uninstall:
+	@if [ -f $(MANIFEST) ]; then \
+		echo "Removing files listed in $(MANIFEST)"; \
+		xargs rm -f < $(MANIFEST); \
+		rm -f $(MANIFEST); \
+		echo "Removing empty directories under $(DESTDIR)$(PREFIX)"; \
+		find $(DESTDIR)$(PREFIX) -type d -empty -delete 2>/dev/null || true; \
+	else \
+		echo "No manifest found at $(MANIFEST); nothing to uninstall"; \
+	fi
+
+clean:
+	@echo "Cleaning $(BUILD_DIR)"
+	@rm -rf $(BUILD_DIR)
+
+help:
+	@echo "Usage: make [target] [PREFIX=/path] [DESTDIR=/staging]"
+	@echo "Targets: all, build, install, uninstall, clean, help"


### PR DESCRIPTION
Install headers to be used by the hardware control apps in `MagAOX` / `XWCTk`.

Installs to `/usr/local/include/summerDevice` by default and only `.h` and `.hpp` files, preserving subdir structure.

Creates `build`, `clean`, `install`, `uninstall` targets.

Creates a manifest file in the `build` dir, recording the path of all installed header.